### PR TITLE
refactor: simplify execute function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "fetch-salesforce-data",
       "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "@quadient/evolve-data-transformations": "^0.0.10"
-      },
       "devDependencies": {
         "@quadient/evolve-scripting-api": "^0.0.39",
         "@typescript-eslint/eslint-plugin": "^6.2.0",
@@ -152,11 +149,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@quadient/evolve-data-transformations": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@quadient/evolve-data-transformations/-/evolve-data-transformations-0.0.10.tgz",
-      "integrity": "sha512-8VHnrYw2Q1X/PnLji6YteghRq2gYBGhEBSG6j8NmPMI92Gpu50YP5AYm20dcXBjapHB7vB2Os2buJDUNCVrnyA=="
     },
     "node_modules/@quadient/evolve-scripting-api": {
       "version": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,5 @@
     "eslint": "^8.45.0",
     "prettier": "3.0.0",
     "typescript": "^4.9.5"
-  },
-  "dependencies": {
-    "@quadient/evolve-data-transformations": "^0.0.10"
   }
 }


### PR DESCRIPTION
* simplify the execute() function through the use of function calls to encapsulate steps
* remove dependency on @quadient/evolve-data-transformations